### PR TITLE
ci: add Dependabot config & clear stale Django alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+updates:
+  # Backend Python (Flask)
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  # Frontend React (npm)
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  # Docker images
+  - package-ecosystem: "docker"
+    directories:
+      - "/backend"
+      - "/db"
+      - "/frontend"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+      include: "scope"


### PR DESCRIPTION
## Contexte

Les 3 alertes Dependabot ouvertes (#69, #70, #71) ciblent **Django `< 5.2.14`** dans un `requirements.txt` à la racine qui **n'existe plus** : Django a été supprimé lors de la migration vers Flask. Ce sont des alertes obsolètes.

GitHub n'expose pas d'API pour forcer un scan de sécurité, mais l'ajout d'une config Dependabot déclenche une **ré-évaluation du dependency graph**, qui devrait fermer automatiquement ces alertes.

## Changements

- Ajout de `.github/dependabot.yml` couvrant les 4 écosystèmes du monorepo :
  - **pip** → `/backend` (Flask)
  - **npm** → `/frontend` (React)
  - **docker** → `/backend`, `/db`, `/frontend`
  - **github-actions** → `/.github/workflows`
- Updates hebdomadaires, messages au format conventional commits.

## Suivi

Après merge, vérifier sur l'onglet Security que les alertes #69/#70/#71 sont passées à *fixed/auto-dismissed*. Si elles persistent, les fermer manuellement (motif : dépendance supprimée).

🤖 Generated with [Claude Code](https://claude.com/claude-code)